### PR TITLE
Fix Dockerfile permissions issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 FROM node:16.14
 
-WORKDIR /app
+WORKDIR /usr/app
 
-COPY package.json package.json
-COPY package-lock.json package-lock.json
+COPY package.json .
+COPY package-lock.json .
 
 RUN npm install
 
+RUN mkdir node_modules/.cache && chmod -R 777 node_modules/.cache
+
 COPY . .
 
+USER node
+
 CMD ["npm", "start"]
+


### PR DESCRIPTION
Ispravljena greška sa permisijama kada se docker-compose pokreće na Linux sistemima.

```
ui_1         | ERROR in EACCES: permission denied, mkdir '/app/node_modules/.cache'
```