### PR TITLE
Ispravljen format datuma i vremena

### DIFF
--- a/src/pages/dashboard/overview.jsx
+++ b/src/pages/dashboard/overview.jsx
@@ -45,7 +45,7 @@ export default function OverviewPage() {
       r["volume"],
       r["change"],
       r["changePercent"],
-      moment(r["time"]).format("DD/MM/YYYY - HH:MM"),
+      moment(r["time"]).format("DD.MM.YYYY HH:mm"),
     ];
   }
 
@@ -54,7 +54,7 @@ export default function OverviewPage() {
       r["fromCurrency"],
       r["toCurrency"],
       r["exchangeRate"],
-      moment(r["time"]).format("DD/MM/YYYY - HH:MM"),
+      moment(r["time"]).format("DD.MM.YYYY HH:mm"),
     ];
   }
 
@@ -63,7 +63,7 @@ export default function OverviewPage() {
       r["symbol"],
       r["high"],
       "EUREX",
-      moment(r["time"]).format("DD/MM/YYYY - HH:MM"),
+      moment(r["time"]).format("DD.MM.YYYY HH:mm"),
     ];
   }
 


### PR DESCRIPTION
Ispravljen format datuma i vremena u tabeli sa hartijama od vrednosti. `MM` ne postoji kao format u moment biblioteci, pa se minute nisu prikazivale ispravno. Takođe, format je promenjen da bude bliži standardu koji koristimo u Srbiji (sa tačkama umesto kosim crtama).

![image](https://user-images.githubusercontent.com/18719127/167504692-e9209f97-92d1-4fed-ad4a-652ed6c0a1e9.png)
